### PR TITLE
Gave user custom error message of ~/.rdb exists on make. Small typo fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 config:
-	mkdir ~/.rdb
-	cp setup/config ~/.rdb/
-	cp setup/localdatabase ~/.rdb/
+	@if [ ! -d ~/.rdb ] ; \
+	then \
+		mkdir ~/.rdb ; \
+		cp setup/config ~/.rdb/ ; \
+		cp setup/localdatabase ~/.rdb/ ; \
+	else \
+		echo '~/.rdb already exists.' ; \
+	fi ;
 install:
 	python setup.py install
-

--- a/ricedb/rice/main.py
+++ b/ricedb/rice/main.py
@@ -30,7 +30,7 @@ class Rice(object):
         self.parser.add_argument(
             'rice', nargs='*', type=str,
             help="""
-            Optionnal positionnal argument, used to look for packages with specified
+            Optionnal positional argument, used to look for packages with specified
             keywords for a specified program.
             USAGE: rice <program_name> [keyword1, keyword2, ...]]
             """


### PR DESCRIPTION
If a user runs make twice, he would get a stack trace. Give custom error instead.